### PR TITLE
Allow custom outputs, not only riemann

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ develop-eggs
 lib
 lib64
 __pycache__
+.cache
+.idea
 
 # Installer logs
 pip-log.txt

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,37 @@ Supermann can be installed with ``pip install supermann``. It's recommended to i
 
 Supervisor can also be installed with ``pip``, or can be installed from your distributions package manager. Once Supermann is installed, add an ``eventlistener`` section to the Supervisor configuration (``/etc/supervisord.conf`` by default) and restart Supervisor.
 
+Usage with Influxdb
+---------------------------
+
+You can use supermann with influxdb output. For example:
+
+* Create /etc/supermann.ini file with contents:
+```ini
+[supermann]
+log_level = INFO
+output_class = supermann.outputs.influx.InfluxOutput
+
+[influx]
+host = <host of influx database>
+username = <username>
+password = <password>
+database = <database>
+
+```
+In influx section you can pass all parameters from here: http://influxdb-python.readthedocs.io/en/latest/api-documentation.html?highlight=InfluxDBClient#influxdbclient
+
+* In your supervisord.conf:
+```ini
+[eventlistener:supermann]
+command=supermann-from-config /etc/supermann.ini
+events=PROCESS_STATE,TICK_5
+
+```
+
+Note, that there is **supermann-from-config** command, not **supermann-from-args**
+
+
 Requirements
 ^^^^^^^^^^^^
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,10 @@
+CHANGELOG
+========================
+
+DEV
+----------------------
+
+* Support for different outputs, not only riemann
+* Added :class:`supermann.outputs.influx.InfluxOutput` output
+* Added supermann-from-config script, for loading configuration from .ini file
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,3 +5,5 @@
 
    supermann
    supermann.metrics
+   supermann.outputs
+   changelog

--- a/docs/supermann.outputs.rst
+++ b/docs/supermann.outputs.rst
@@ -1,0 +1,6 @@
+supermann.outputs package
+====================================
+
+.. automodule:: supermann.outputs
+    :members:
+    :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setuptools.setup(
         'click>=6.6',
         'psutil>=4.3.0',
         'riemann-client>=6.3.0',
-        'supervisor>=3.0,<4.0'
+        'supervisor>=3.0,<4.0',
+        'influxdb==5.*'
     ],
 
     entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setuptools.setup(
     entry_points = {
         'console_scripts': [
             'supermann = supermann.cli:main',
-            'supermann-from-file = supermann.cli:from_file'
+            'supermann-from-file = supermann.cli:from_file',
+            'supermann-from-config = supermann.cli:from_config'
         ]
     },
 

--- a/supermann/cli.py
+++ b/supermann/cli.py
@@ -2,7 +2,11 @@
 
 from __future__ import absolute_import
 
+import logging
+from ConfigParser import ConfigParser, SafeConfigParser, NoOptionError
+
 import click
+import sys
 
 import supermann.core
 import supermann.utils
@@ -24,13 +28,19 @@ import supermann.utils
 def main(log_level, host, port, system):
     """The main entry point for Supermann"""
     # Log messages are sent to stderr, and Supervisor takes care of the rest
-    supermann.utils.configure_logging(log_level)
 
-    s = supermann.core.Supermann(host, port)
-    if system:
-        s.connect_system_metrics()
-    s.connect_process_metrics()
-    s.run()
+    try:
+        supermann.utils.configure_logging(log_level)
+
+        s = supermann.core.Supermann(host, port)
+        if system:
+            s.connect_system_metrics()
+        s.connect_process_metrics()
+        s.run()
+    except Exception as e:
+        logging.exception("Exception running supermann: %s", e)
+        raise e, None, sys.exc_traceback
+
 
 
 @click.command()
@@ -38,3 +48,42 @@ def main(log_level, host, port, system):
 def from_file(config):
     """An alternate entry point that reads arguments from a file."""
     main.main(args=config.read().split())
+
+@click.command()
+@click.argument('config', type=click.File('r'))
+def from_config(config):
+    """
+    Entry point that reads arguments from a .ini config
+    """
+
+    parser = ConfigParser()
+    parser.readfp(config)
+
+    try:
+        log_level = parser.get("supermann", "log_level")
+    except NoOptionError:
+        log_level = "INFO"
+
+    try:
+        system = parser.getboolean("supermann", "system")
+    except NoOptionError:
+        system = True
+
+    try:
+        output_class = parser.get("supermann", "output_class")
+    except NoOptionError:
+        output_class = "supermann.outputs.riemann.RiemannOutput"
+
+    try:
+        supermann.utils.configure_logging(log_level)
+
+        s = supermann.core.Supermann()
+        s.load_output(output_class, parser)
+
+        if system:
+            s.connect_system_metrics()
+        s.connect_process_metrics()
+        s.run()
+    except Exception as e:
+        logging.exception("Exception running supermann: %s", e)
+        raise e, None, sys.exc_traceback

--- a/supermann/metrics/process.py
+++ b/supermann/metrics/process.py
@@ -42,10 +42,10 @@ def cpu(sender, process, data):
     - ``process:{name}:cpu:percent``
     - ``process:{name}:cpu:absolute``
     """
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:cpu:percent'.format(**data),
         metric_f=process.cpu_percent(interval=None))
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:cpu:absolute'.format(**data),
         metric_f=sum(process.cpu_times()))
 
@@ -59,13 +59,13 @@ def mem(sender, process, data):
     - ``process:{name}:mem:rss:percent``
     """
     memory_info = process.memory_info()
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:mem:virt:absolute'.format(name=data['name']),
         metric_f=memory_info.vms)
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:mem:rss:absolute'.format(name=data['name']),
         metric_f=memory_info.rss)
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:mem:rss:percent'.format(name=data['name']),
         metric_f=process.memory_percent())
 
@@ -78,10 +78,10 @@ def fds(sender, process, data):
     - ``process:{name}:fds:percent``
     """
     num_fds = process.num_fds()
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:fds:absolute'.format(**data),
         metric_f=num_fds)
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:fds:percent'.format(**data),
         metric_f=(num_fds / get_nofile_limit(process.pid)) * 100)
 
@@ -105,9 +105,9 @@ def io(sender, process, data):
         read_bytes = dict(metric_f=io_counters.read_bytes)
         write_bytes = dict(metric_f=io_counters.write_bytes)
 
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:io:read:bytes'.format(**data), **read_bytes)
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:io:write:bytes'.format(**data), **write_bytes)
 
 
@@ -116,7 +116,7 @@ def state(sender, process, data):
 
     - ``process:{name}:state``
     """
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:state'.format(**data),
         state=data['statename'].lower())
 
@@ -126,6 +126,6 @@ def uptime(sender, process, data):
 
     - ``process:{name}:uptime``
     """
-    sender.riemann.event(
+    sender.output_client.event(
         service='process:{name}:uptime'.format(**data),
         metric_f=data['stop' if process is None else 'now'] - data['start'])

--- a/supermann/metrics/process.py
+++ b/supermann/metrics/process.py
@@ -68,14 +68,6 @@ def mem(sender, process, data):
     :type process: Process
     """
 
-    logging.error(process.memory_info().rss)
-    total = 0
-    for c in process.children():
-        logging.error("{}, {}".format(c.memory_info().rss, c.children()))
-        total += c.memory_info().rss
-
-    logging.error(process.memory_info().rss + total)
-
     sender.output_client.event(
         service='process:{name}:mem:virt:absolute'.format(name=data['name']),
         metric_f=with_children(process, lambda p: p.memory_info().vms))

--- a/supermann/metrics/system.py
+++ b/supermann/metrics/system.py
@@ -30,6 +30,7 @@ def mem(self, event):
     self.output_client.event(service='system:mem:percent', metric_f=mem.percent)
     self.output_client.event(service='system:mem:total', metric_f=mem.total)
     self.output_client.event(service='system:mem:free', metric_f=mem.free)
+    self.output_client.event(service='system:mem:used', metric_f=mem.used)
     self.output_client.event(service='system:mem:cached', metric_f=mem.cached)
     self.output_client.event(service='system:mem:buffers', metric_f=mem.buffers)
 

--- a/supermann/metrics/system.py
+++ b/supermann/metrics/system.py
@@ -12,7 +12,7 @@ def cpu(self, event):
 
     - ``system:cpu:percent``
     """
-    self.riemann.event(
+    self.output_client.event(
         service='system:cpu:percent',
         metric_f=psutil.cpu_percent(interval=None))
 
@@ -27,11 +27,11 @@ def mem(self, event):
     - ``system:mem:buffers``
     """
     mem = psutil.virtual_memory()
-    self.riemann.event(service='system:mem:percent', metric_f=mem.percent)
-    self.riemann.event(service='system:mem:total', metric_f=mem.total)
-    self.riemann.event(service='system:mem:free', metric_f=mem.free)
-    self.riemann.event(service='system:mem:cached', metric_f=mem.cached)
-    self.riemann.event(service='system:mem:buffers', metric_f=mem.buffers)
+    self.output_client.event(service='system:mem:percent', metric_f=mem.percent)
+    self.output_client.event(service='system:mem:total', metric_f=mem.total)
+    self.output_client.event(service='system:mem:free', metric_f=mem.free)
+    self.output_client.event(service='system:mem:cached', metric_f=mem.cached)
+    self.output_client.event(service='system:mem:buffers', metric_f=mem.buffers)
 
 
 def swap(self, event):
@@ -41,8 +41,8 @@ def swap(self, event):
     - ``system:swap:absolute``
     """
     swap = psutil.swap_memory()
-    self.riemann.event(service='system:swap:percent', metric_f=swap.percent)
-    self.riemann.event(service='system:swap:absolute', metric_f=swap.used)
+    self.output_client.event(service='system:swap:percent', metric_f=swap.percent)
+    self.output_client.event(service='system:swap:absolute', metric_f=swap.used)
 
 
 def load(self, event):
@@ -53,9 +53,9 @@ def load(self, event):
     - ``system:load:15min``
     """
     load1, load5, load15 = os.getloadavg()
-    self.riemann.event(service='system:load:1min', metric_f=load1)
-    self.riemann.event(service='system:load:5min', metric_f=load5)
-    self.riemann.event(service='system:load:15min', metric_f=load15)
+    self.output_client.event(service='system:load:1min', metric_f=load1)
+    self.output_client.event(service='system:load:5min', metric_f=load5)
+    self.output_client.event(service='system:load:15min', metric_f=load15)
 
 
 def load_scaled(self, event):
@@ -64,7 +64,7 @@ def load_scaled(self, event):
     - ``system:load_scaled:1min``
     """
     load1 = os.getloadavg()[0] / psutil.cpu_count()
-    self.riemann.event(service='system:load_scaled:1min', metric_f=load1)
+    self.output_client.event(service='system:load_scaled:1min', metric_f=load1)
 
 
 def uptime(self, event):
@@ -74,4 +74,4 @@ def uptime(self, event):
     """
     with open('/proc/uptime', 'r') as f:
         uptime, idle = map(float, f.read().strip().split())
-    self.riemann.event(service='system:uptime', metric_f=uptime)
+    self.output_client.event(service='system:uptime', metric_f=uptime)

--- a/supermann/outputs/__init__.py
+++ b/supermann/outputs/__init__.py
@@ -1,0 +1,21 @@
+import imp
+import importlib
+import logging
+
+from supermann.outputs.riemann import RiemannOutput
+
+
+def load_output(classPath):
+
+    #by default return Riemann output
+    if not classPath:
+        return RiemannOutput()
+
+    mdl, cls = classPath.rsplit(".", 1)
+
+    try:
+        return getattr(importlib.import_module(mdl), cls)()
+    except:
+        logging.exception("Can't load module %s", classPath)
+        raise AttributeError("Module {} not found".format(classPath))
+

--- a/supermann/outputs/__init__.py
+++ b/supermann/outputs/__init__.py
@@ -1,3 +1,47 @@
+"""
+This package describes output classes for collected metrics.
+
+supermann.outputs.base
+-----------------------------
+
+Base class for all outputs. New outputs should inherit it
+
+.. automodule:: supermann.outputs.base
+    :members:
+    :show-inheritance:
+
+
+supermann.outputs.debug
+---------------------------------
+
+Debug output, just log metrics in stderr
+
+.. automodule:: supermann.outputs.debug
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+supermann.outputs.influx
+-----------------------------------
+
+Write metrics into influxdb
+
+.. automodule:: supermann.outputs.influx
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+supermann.outputs.riemann
+--------------------------------
+
+Write metrics into riemann. Used as default
+
+.. automodule:: supermann.outputs.riemann
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+"""
 import imp
 import importlib
 import logging

--- a/supermann/outputs/_base.py
+++ b/supermann/outputs/_base.py
@@ -1,0 +1,45 @@
+from ConfigParser import ConfigParser
+
+
+class BaseOutput(object):
+    section_name = None
+
+    def __init__(self):
+        assert self.section_name, "Section name is required!"
+
+    def init(self, **params):
+        """
+        This method called in Supermann initialization and should initialize output.
+        """
+        raise NotImplemented
+
+    def __enter__(self):
+        """
+        By default do nothing
+        :return:
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        By default do nothing
+        """
+
+    def init_from_configparser(self, parser):
+        #type: (ConfigParser)->None
+        assert self.section_name, "Section name is required!"
+
+        self.init(**dict(parser.items(self.section_name)))
+
+    def event(self, **data):
+        """
+        Should save one event metric data in bulk
+        :param data:
+        """
+        raise NotImplementedError
+
+    def flush(self):
+        """
+        Should send bulk in output
+        """
+        raise NotImplementedError

--- a/supermann/outputs/base.py
+++ b/supermann/outputs/base.py
@@ -2,6 +2,9 @@ from ConfigParser import ConfigParser
 
 
 class BaseOutput(object):
+    """
+    Base class for all outputs
+    """
     section_name = None
 
     def __init__(self):
@@ -9,7 +12,8 @@ class BaseOutput(object):
 
     def init(self, **params):
         """
-        This method called in Supermann initialization and should initialize output.
+        This method called in Supermann initialization and
+        should initialize output.
         """
         raise NotImplemented
 

--- a/supermann/outputs/debug.py
+++ b/supermann/outputs/debug.py
@@ -1,0 +1,18 @@
+import logging
+
+from supermann.outputs._base import BaseOutput
+import supermann
+
+class DebugOutput(BaseOutput):
+    section_name = "debug_output"
+
+    def init(self, **params):
+        supermann.utils.getLogger(self).info(
+            "Using DebugOutput")
+
+    def flush(self):
+        pass
+
+    def event(self, **data):
+        logging.error(str(data))
+

--- a/supermann/outputs/debug.py
+++ b/supermann/outputs/debug.py
@@ -1,6 +1,6 @@
 import logging
 
-from supermann.outputs._base import BaseOutput
+from supermann.outputs.base import BaseOutput
 import supermann
 
 class DebugOutput(BaseOutput):

--- a/supermann/outputs/influx.py
+++ b/supermann/outputs/influx.py
@@ -7,10 +7,7 @@ import sys
 import supermann
 from supermann.outputs.base import BaseOutput
 
-try:
-    from influxdb.client import InfluxDBClient
-except ImportError:
-    logging.error("influxdb package not installed. You won't be able to use InfluxDbOutput")
+from influxdb.client import InfluxDBClient
 
 class Point(object):
     point = None
@@ -59,9 +56,6 @@ class InfluxOutput(BaseOutput):
         self.bulk = []
 
     def flush(self):
-        for p in self.bulk:
-            logging.error(p)
-
         self.influx_client.write_points(
             [p.to_influx() for p in self.bulk]
         )

--- a/supermann/outputs/influx.py
+++ b/supermann/outputs/influx.py
@@ -5,7 +5,7 @@ import socket
 import sys
 
 import supermann
-from supermann.outputs._base import BaseOutput
+from supermann.outputs.base import BaseOutput
 
 try:
     from influxdb.client import InfluxDBClient
@@ -32,6 +32,15 @@ class Point(object):
 
 
 class InfluxOutput(BaseOutput):
+    """
+    Writes point into influxdb.
+
+    Each system metrics will be written into separated measurement.
+    All process metrics will be tagged by process_name and will be written into
+    separated metrics.
+
+    All points will be tagged with hostname.
+    """
     section_name = "influx"
 
     hostname = socket.gethostname()

--- a/supermann/outputs/influx.py
+++ b/supermann/outputs/influx.py
@@ -1,0 +1,92 @@
+import logging
+import re
+import socket
+
+import sys
+
+import supermann
+from supermann.outputs._base import BaseOutput
+
+try:
+    from influxdb.client import InfluxDBClient
+except ImportError:
+    logging.error("influxdb package not installed. You won't be able to use InfluxDbOutput")
+
+class Point(object):
+    point = None
+    tags = None
+    measurement = None
+
+    def __init__(self, **k):
+        self.__dict__.update(k)
+
+    def __repr__(self):
+        return "Point({}, {}, {})".format(self.measurement, self.point, self.tags)
+
+    def to_influx(self):
+        return dict(
+            measurement=self.measurement,
+            tags=self.tags,
+            fields=self.point
+        )
+
+
+class InfluxOutput(BaseOutput):
+    section_name = "influx"
+
+    hostname = socket.gethostname()
+    processname_pattern = re.compile(r"^process:([^\:]+):(.*)")
+
+    def init(self, **params):
+        self.influx_client = InfluxDBClient(
+            **params
+        )
+
+        supermann.utils.getLogger(self).info(
+            "Using InfluxOutput with params %s", str(params))
+
+    def __init__(self):
+        super(InfluxOutput, self).__init__()
+        self.bulk = []
+
+    def flush(self):
+        for p in self.bulk:
+            logging.error(p)
+
+        self.influx_client.write_points(
+            [p.to_influx() for p in self.bulk]
+        )
+
+        self.bulk = []
+
+    def event(self, **data):
+
+        try:
+            service = data["service"]
+            metric = data["metric_f"]
+        except:
+            return
+
+        if service.startswith("system"):
+            self.bulk.append(Point(
+                measurement=service,
+                point={
+                    "metric": metric
+                },
+                tags={
+                    "hostname": self.hostname
+                }
+            ))
+        elif service.startswith("process"):
+            processname, tail = self.processname_pattern.findall(service)[0]
+
+            self.bulk.append(Point(
+                measurement="process:{}".format(tail),
+                point={
+                    "metric": metric
+                },
+                tags={
+                    "hostname": self.hostname,
+                    "process": processname
+                }
+            ))

--- a/supermann/outputs/riemann.py
+++ b/supermann/outputs/riemann.py
@@ -2,7 +2,7 @@ import riemann_client
 from riemann_client.client import QueuedClient
 
 import supermann
-from supermann.outputs._base import BaseOutput
+from supermann.outputs.base import BaseOutput
 
 class RiemannOutput(BaseOutput):
     section_name = "riemann"

--- a/supermann/outputs/riemann.py
+++ b/supermann/outputs/riemann.py
@@ -1,0 +1,38 @@
+import riemann_client
+from riemann_client.client import QueuedClient
+
+import supermann
+from supermann.outputs._base import BaseOutput
+
+class RiemannOutput(BaseOutput):
+    section_name = "riemann"
+
+    def init(self, **params):
+        """
+        Initialization of output
+
+        :param host: required, host
+        :param port: required, port
+
+        Other params are depend on kind of output
+        """
+        self.host = params["host"]
+        self.port = params["port"]
+        self.riemann = riemann_client.client.QueuedClient(
+            riemann_client.transport.TCPTransport(self.host, self.port))  #type: QueuedClient
+
+        supermann.utils.getLogger(self).info(
+            "Using Riemann protobuf server at {0}:{1}".format(self.host, self.port))
+
+    def __enter__(self):
+        self.riemann.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.riemann.__exit__(exc_type, exc_val, exc_tb)
+
+    def event(self, **data):
+        self.riemann.event(**data)
+
+    def flush(self):
+        self.riemann.flush()

--- a/supermann/tests/supermann.ini
+++ b/supermann/tests/supermann.ini
@@ -1,0 +1,10 @@
+[supermann]
+
+output_class = supermann.outputs.influx.InfluxOutput
+
+[influx]
+host = test.host
+username = admin
+password = password
+database = database
+

--- a/supermann/tests/test_metrics.py
+++ b/supermann/tests/test_metrics.py
@@ -1,0 +1,19 @@
+from multiprocessing.pool import Pool
+
+import psutil
+import pytest
+
+from supermann.metrics.process import with_children
+
+
+@pytest.fixture()
+def process():
+    #create process pull
+    pool = Pool(5)
+    return psutil.Process()
+
+def test_with_children(process):
+    #type: (psutil.Process)->None
+    assert len(process.children()) == 5
+
+    assert with_children(process, lambda p: p.memory_info().rss) > process.memory_info().rss

--- a/supermann/tests/test_supermann.py
+++ b/supermann/tests/test_supermann.py
@@ -46,7 +46,7 @@ def getAllProcessInfo():
 @mock.patch('supermann.supervisor.Supervisor', autospec=True)
 @mock.patch('riemann_client.transport.TCPTransport', autospec=True)
 def supermann_instance(riemann_client_class, supervisor_class):
-    instance = Supermann(None, None).with_all_recivers()
+    instance = Supermann("localhost", None).with_all_recivers()
     instance.supervisor.configure_mock(**{
         # At least one process must be visible for the process metrics to run
         'rpc.getAllProcessInfo': mock.Mock(wraps=getAllProcessInfo),
@@ -60,11 +60,11 @@ def supermann_instance(riemann_client_class, supervisor_class):
 
 
 def test_riemann_client(supermann_instance):
-    assert supermann_instance.riemann.transport.connect.called
+    assert supermann_instance.output_client.riemann.transport.connect.called
 
 
 def test_one_message_per_event(supermann_instance):
-    assert len(supermann_instance.riemann.transport.send.call_args_list) == 2
+    assert len(supermann_instance.output_client.riemann.transport.send.call_args_list) == 2
 
 
 def test_supervisor_rpc_called(supermann_instance):


### PR DESCRIPTION
Thank you for this lib. But we use influxdb as our metric storage. So I've added functionality to write different outputs, and provided InfluxOutput class.

Also because in case of different outputs configuration may be complex, I've added support for .ini configuration.